### PR TITLE
Formal proof on exercise 2.2.5.2

### DIFF
--- a/ch02/2.2/2.2.md
+++ b/ch02/2.2/2.2.md
@@ -162,7 +162,7 @@ Construct unambiguous context-free grammars for each ofthe following languages.
 Construct a context-free grammar for roman numerals.
 **Note:** we just consider a subset of roman numerals which is less than 4k.
 #### answer[wikipedia: Roman_numerals](http://en.wikipedia.org/wiki/Roman_numerals)
-- via wikipedia, we can categorize the single noman numerals into 4 groups:
+- via wikipedia, we can categorize the single roman numerals into 4 groups:
 
     ```
     I, II, III | I V | V, V I, V II, V III | I X


### PR DESCRIPTION
This patch improves some of the contents in the exercises solutions for section 2.2.7. The most significant improvement is on exercise 2.2.5 b), which had a pending TODO for a formal proof that the grammar doesn't generate all binary strings with values divisible by 3.

Other minor improvements throughout the document have been done.
