### PR TITLE
Correct one mistake in ch02/2.3/2.3.md : section 2.3.3

### DIFF
--- a/ch02/2.3/2.3.md
+++ b/ch02/2.3/2.3.md
@@ -90,7 +90,7 @@ num -> thousand hundred ten digit
 thousand -> low {thousand.roman = repeat('M', low.v)}
 hundred -> low {hundred.roman = repeat('C', low.v)}
          | 4 {hundred.roman = 'CD'}
-         | high {hundred.roman = 'D' || repeat('X', high.v - 5)}
+         | high {hundred.roman = 'D' || repeat('C', high.v - 5)}
          | 9 {hundred.roman = 'CM'}
 ten -> low {ten.roman = repeat('X', low.v)}
      | 4 {ten.roman = 'XL'}


### PR DESCRIPTION
Within Section 2.3.3:
    "   hundred -> high {hundred.roman = 'D' || repeat ('X',high.v - 5)} "
 should be correct:
    "   hundred -> high {hundred.roman = 'D' || repeat ('C',high.v - 5)} "
