### PR TITLE
Parser table of question 4.4.1.f fixed

### DIFF
--- a/ch04/4.4/4.4.md
+++ b/ch04/4.4/4.4.md
@@ -269,7 +269,7 @@
     follow(bterm) = follow(bterm') = [or, $]
     follow(bfactor) = [and, $]
    
-    ````
+    ```
     
     step4. 预测分析表
     
@@ -326,11 +326,11 @@
             </tr>
             <tr>
                 <th>bterm'</th>
-                <td></td>
                 <td>bterm' -> and bfactor bterm'</td>
-                <td></td>
-                <td></td>
                 <td>bterm' -> ε</td>
+                <td></td>
+                <td></td>
+                <td></td>
                 <td></td>
                 <td></td>
                 <td>bterm' -> ε</td>


### PR DESCRIPTION
The line referred to production bterm' is wrong. The firsts of bterm' are `and` and `ε` and the follows are `or` and `$`. So the table needs to be modified to represent that.
