### PR TITLE
Fixed parse tree not showing

### DIFF
--- a/ch04/4.2/4.2.md
+++ b/ch04/4.2/4.2.md
@@ -22,7 +22,7 @@ and the string aa + a*.
 2. S =rm=> SS\* => Sa\* => SS+a\* => Sa+a\* => aa+a\*
 3.
 
-    ![4 2 1](https://f.cloud.github.com/assets/340282/469058/c08b4f9c-b6af-11e2-8236-f79c6a56215a.gif)
+![4 2 1](https://f.cloud.github.com/assets/340282/469058/c08b4f9c-b6af-11e2-8236-f79c6a56215a.gif)
 
 4. Unambiguous
 5. The set of all postfix expressions consist of addition and multiplication


### PR DESCRIPTION
Just adjusted file for section 4.2, because the formatting was preventing a parse tree image from displaying.