### PR TITLE
Fix 5.3.2 solution

### DIFF
--- a/ch05/5.3/5.3.md
+++ b/ch05/5.3/5.3.md
@@ -55,7 +55,6 @@
 
 几个属性设置：
 
-- wrapped: 表达式最外层是否有括号。
 - precedence: 令 +，\*，() 和单 digit 的优先级分别为 0，1，2，3。 如果表达式最外层有括号，则为去掉括号后最后被计算的运算符的优先级，否则为表达式最后被计算的运算符的优先级。
 - expr: 表达式。
 - cleanExpr: 去除了冗余括号的表达式。
@@ -73,24 +72,22 @@
             <td>1)</td>
             <td>L -> En</td>
             <td>
-                L.cleanExpr = E.wrapped ? E.cleanExpr : E.expr
+                L.cleanExpr = E.cleanExpr
             </td>
         </tr>
         <tr>
             <td>2)</td>
             <td>E -> E_1 + T</td>
             <td>
-                E.wrapped = false<br/>
                 E.precedence = 0<br/>
                 E.expr = E_1.expr || "+" || T.expr<br/>
-                E.cleanExpr = (E_1.wrapped ? E_1.cleanExpr : E_1.expr) || "+" || (T.wrapped ? T.cleanExpr : T.expr)
+                E.cleanExpr = E_1.cleanExpr || "+" || T.cleanExpr
             </td>
         </tr>
         <tr>
             <td>3)</td>
             <td>E -> T</td>
             <td>
-                E.wrapped = T.wrapped<br/>
                 E.precedence = T.precedence<br/>
                 E.expr = T.expr</br>
                 E.cleanExpr = T.cleanExpr
@@ -100,17 +97,15 @@
             <td>4)</td>
             <td>T -> T_1 * F</td>
             <td>
-                T.wrapped = false<br/>
                 T.precedence = 1<br/>
                 T.expr = T_1.expr || "*" || F.expr<br/>
-                T.cleanExpr = (T_1.wrapped && T_1.precedence >= 1 ? T_1.cleanExpr : T_1) || * || (F.wrapped && F.precedence >= 1 ? F.cleanExpr : F.expr)
+                T.cleanExpr = (T_1.precedence >= 1 ? T_1.cleanExpr : T_1.expr) || * || (F.precedence > 1 ? F.cleanExpr : F.expr)
             </td>
         </tr>
         <tr>
             <td>5)</td>
             <td>T -> F</td>
             <td>
-                T.wrapped = F.wrapped<br/>
                 T.precedence = F.precedence<br/>
                 T.expr = F.expr<br/>
                 T.cleanExpr = F.cleanExpr
@@ -120,17 +115,15 @@
             <td>6)</td>
             <td>F -> (E)</td>
             <td>
-                F.wrapped = true<br/>
                 F.precedence = E.precedence<br/>
                 F.expr = "(" || E.expr || ")"<br/>
-                F.cleanExpr = E.expr
+                F.cleanExpr = E.cleanExpr
             </td>
         </tr>
         <tr>
             <td>7)</td>
             <td>F -> digit</td>
             <td>
-                F.wrapped = false<br/>
                 F.precedence = 3<br/>
                 F.expr = digit<br/>
                 F.cleanExpr = digit

--- a/ch05/5.3/5.3.md
+++ b/ch05/5.3/5.3.md
@@ -80,8 +80,7 @@
             <td>E -> E_1 + T</td>
             <td>
                 E.precedence = 0<br/>
-                E.expr = E_1.expr || "+" || T.expr<br/>
-                E.cleanExpr = E_1.cleanExpr || "+" || T.cleanExpr
+                E.cleanExpr = E_1.cleanExpr || "+" || (T.precedence > 0 ? T.cleanExpr : T.expr)
             </td>
         </tr>
         <tr>
@@ -89,7 +88,6 @@
             <td>E -> T</td>
             <td>
                 E.precedence = T.precedence<br/>
-                E.expr = T.expr</br>
                 E.cleanExpr = T.cleanExpr
             </td>
         </tr>
@@ -98,8 +96,8 @@
             <td>T -> T_1 * F</td>
             <td>
                 T.precedence = 1<br/>
-                T.expr = T_1.expr || "*" || F.expr<br/>
-                T.cleanExpr = (T_1.precedence >= 1 ? T_1.cleanExpr : T_1.expr) || * || (F.precedence > 1 ? F.cleanExpr : F.expr)
+                T.expr = (T_1.precedence >= 1 ? T_1.cleanExpr : T_1.expr) || * || (F.precedence > 1 ? F.cleanExpr : F.expr)<br/>
+                T.cleanExpr = T.expr
             </td>
         </tr>
         <tr>
@@ -116,7 +114,7 @@
             <td>F -> (E)</td>
             <td>
                 F.precedence = E.precedence<br/>
-                F.expr = "(" || E.expr || ")"<br/>
+                F.expr = "(" || E.cleanExpr || ")"<br/>
                 F.cleanExpr = E.cleanExpr
             </td>
         </tr>


### PR DESCRIPTION
The original solution can't work out the following examples correctly:
* ((a+b)) -> a+b
* (a+b)+c -> a+b+c
* ((a+b)+c)+d -> a+b+c+d
* etc.

We don't need a property for if the expression is wrapped or not. Just write the wrapped expression (if applicable) into expr and cleanExpr if not, then it's done!

Always remember a+(b+c) does not equals a+b+c  since they have completely different calulation order.