### PR TITLE
Fixed a small bug in the 3.1 exercise

### DIFF
--- a/ch03/3.1/3.1.md
+++ b/ch03/3.1/3.1.md
@@ -5,7 +5,7 @@
 Divide the following C++ program:
 
 ```
-float limitedSquare(x){float x;
+float limitedSquare(x) float x {
   /* returns x-squared, nut never more than 100 */
   return (x <= -10.0 || x >= 10.0) ? 100 : x*x;
 }
@@ -17,8 +17,7 @@ Which lexemes should get associated lexical values? What should those values be?
 #### Answer
 
 ```
-<float> <id, limitedSquaare> <(> <id, x> <)> <{>
-  <float> <id, x>
+<float> <id, limitedSquaare> <(> <id, x> <)> <float> <id, x> <{>
   <return> <(> <id, x> <op,"<="> <num, -10.0> <op, "||"> <id, x> <op, ">="> <num, 10.0> <)> <op, "?"> <num, 100> <op, ":"> <id, x> <op, "*"> <id, x>
 <}>
 ```


### PR DESCRIPTION
'float x' is not a local variable declaration here. It is a formal parameter declaration (see [Obsolete Forms of Function Declarations and Definitions](https://learn.microsoft.com/en-us/cpp/c-language/obsolete-forms-of-function-declarations-and-definitions?view=msvc-170) for more details).